### PR TITLE
Handling the implicit time parameter properly

### DIFF
--- a/lib/fluent/plugin/in_httpenhanced.rb
+++ b/lib/fluent/plugin/in_httpenhanced.rb
@@ -15,11 +15,10 @@ module Fluent
 
           tag = @default_tag if tag == '' && @default_tag != ''
           record = params
-          time = params['time']
-          time ||= params['t']
-          time = time[0..9].to_i  # just make sure that its 10 digits epoch time in seconds not miliseconds
-          if time == 0
-            time = Engine.now
+          time = (params['time'] || params['t'] || Engine.now).to_i
+          # Just make sure that it's a 10-digit epoch time in seconds not milliseconds
+          if time >= 10**10
+            time /= 1000
           end
         rescue
           return ["400 Bad Request", {'Content-type'=>'text/plain'}, "400 Bad Request\n#{$!}\n"]


### PR DESCRIPTION
I believe that the intended behavior was to use Engine.now whenever "t=..." or "time=..." are missing from the URL parameter. Right now, these situations result in 400 Bad Request. This patch should fix that.
