### PR TITLE
Updated for dependencies and new version of Fluentd

### DIFF
--- a/fluent-plugin-http-enhanced.gemspec
+++ b/fluent-plugin-http-enhanced.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |gem|
   gem.description = "Enhanced HTTP input plugin for Fluent event collector"
   gem.homepage = "https://github.com/parolkar/fluent-plugin-http-enhanced"
   gem.summary = gem.description
-  gem.version = "0.0.5"
+  gem.version = "0.0.6"
   gem.authors = ["Abhishek Parolkar"]
   gem.email = "abhishek@parolkar.com"
   gem.has_rdoc = false
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
-  gem.add_dependency "fluentd", "~> 0.10.8"
+  gem.add_dependency "fluentd", "~> 0.12.5"
 end
 
 

--- a/lib/fluent/plugin/in_httpenhanced.rb
+++ b/lib/fluent/plugin/in_httpenhanced.rb
@@ -1,5 +1,7 @@
+require 'fluent/plugin/in_http.rb'
+
 module Fluent
-  class HttpEnhanced < Fluent::HttpInput
+  class HttpEnhanced < Fluent::Plugin::HttpInput
     Plugin.register_input('httpenhanced', self)
 
     config_param :full_query_string_record, :bool, :default => 'false'
@@ -24,7 +26,7 @@ module Fluent
           return ["400 Bad Request", {'Content-type'=>'text/plain'}, "400 Bad Request\n#{$!}\n"]
         end
         begin
-          Engine.emit(tag, time, record)
+          router.emit(tag, time, record)
         rescue
           return ["500 Internal Server Error", {'Content-type'=>'text/plain'}, "500 Internal Server Error\n#{$!}\n"]
         end


### PR DESCRIPTION
Hi, I wanted to use this plugin on TD-agent 3.8.1 and it failed to install because of a dependency on msgpack-0.5.12.gem which failed to build native extensions. 

After changing dependencies I stumbled upon the fact that the HTTP input class is now in a plugin module and also the Engine call to emit changed to 'router'. 

After changing these things the plugin works fine. So that's why I created this PR. Could save others some time.

